### PR TITLE
Implement plugin bootstrapping

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden

--- a/includes/class-vintel-zoho-loader.php
+++ b/includes/class-vintel-zoho-loader.php
@@ -1,0 +1,13 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+class Vintel_Zoho_Loader {
+    /**
+     * Initialize plugin hooks.
+     */
+    public function init() {
+        // Initialization code will go here in later steps.
+    }
+}

--- a/includes/index.php
+++ b/includes/index.php
@@ -1,0 +1,1 @@
+<?php // Silence is golden

--- a/main.php
+++ b/main.php
@@ -16,3 +16,22 @@ define( 'VINTEL_ZOHO_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
 // Load includes
 require_once VINTEL_ZOHO_PLUGIN_PATH . 'includes/class-vintel-zoho-loader.php';
+
+// Activation hook
+function vintel_zoho_activate() {
+    // Placeholder for activation logic.
+}
+register_activation_hook( __FILE__, 'vintel_zoho_activate' );
+
+// Deactivation hook
+function vintel_zoho_deactivate() {
+    // Placeholder for deactivation logic.
+}
+register_deactivation_hook( __FILE__, 'vintel_zoho_deactivate' );
+
+// Initialize plugin after all plugins are loaded.
+function vintel_zoho_init() {
+    $loader = new Vintel_Zoho_Loader();
+    $loader->init();
+}
+add_action( 'plugins_loaded', 'vintel_zoho_init' );


### PR DESCRIPTION
## Summary
- rename plugin entry file to `main.php`
- add activation and deactivation hooks
- initialize loader via `plugins_loaded`
- scaffold `includes` and `admin` directories with a loader class

## Testing
- `php -l main.php` *(fails: `php: command not found`)*