### PR TITLE
Fix fatal error due to duplicate function

### DIFF
--- a/main.php
+++ b/main.php
@@ -14,19 +14,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'VINTEL_ZOHO_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'VINTEL_ZOHO_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
-// Activation hook to set default options
-register_activation_hook( __FILE__, 'vintel_zoho_activate' );
-function vintel_zoho_activate() {
-    add_option( 'vintel_zoho_debug', 0 );
-}
-
 // Load includes
 require_once VINTEL_ZOHO_PLUGIN_PATH . 'includes/functions.php';
 require_once VINTEL_ZOHO_PLUGIN_PATH . 'includes/class-vintel-zoho-loader.php';
 
-// Activation hook
+// Activation hook to set default options
 function vintel_zoho_activate() {
-    // Placeholder for activation logic.
+    add_option( 'vintel_zoho_debug', 0 );
 }
 register_activation_hook( __FILE__, 'vintel_zoho_activate' );
 


### PR DESCRIPTION
## Summary
- remove duplicate activation hook and combine logic

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n 1 -I{} php -l {}`