### PR TITLE
Fix OAuth token option naming

### DIFF
--- a/includes/class-vintel-zoho-api.php
+++ b/includes/class-vintel-zoho-api.php
@@ -85,9 +85,9 @@ class Vintel_Zoho_API {
      * @return string|WP_Error Access token string or WP_Error on failure.
      */
     private function maybe_refresh_token() {
-        $access_token  = get_option( 'vintel_zoho_access_token' );
-        $refresh_token = get_option( 'vintel_zoho_refresh_token' );
-        $expires_at    = (int) get_option( 'vintel_zoho_token_expires_at' );
+        $access_token  = get_option( 'zoho_access_token' );
+        $refresh_token = get_option( 'zoho_refresh_token' );
+        $expires_at    = (int) get_option( 'zoho_token_expires_at' );
 
         if ( empty( $access_token ) || empty( $refresh_token ) ) {
             return new WP_Error( 'missing_tokens', __( 'Zoho Desk tokens are missing.', 'vintel-zoho-desk-connector' ) );
@@ -126,8 +126,8 @@ class Vintel_Zoho_API {
             $access_token = sanitize_text_field( $body['access_token'] );
             $expires_in   = isset( $body['expires_in'] ) ? intval( $body['expires_in'] ) : 3600;
 
-            update_option( 'vintel_zoho_access_token', $access_token );
-            update_option( 'vintel_zoho_token_expires_at', time() + $expires_in );
+            update_option( 'zoho_access_token', $access_token );
+            update_option( 'zoho_token_expires_at', time() + $expires_in );
 
             return $access_token;
         }

--- a/includes/class-vintel-zoho-loader.php
+++ b/includes/class-vintel-zoho-loader.php
@@ -50,9 +50,9 @@ class Vintel_Zoho_Loader {
         register_setting( 'vintel_zoho_settings', 'vintel_zoho_client_id' );
         register_setting( 'vintel_zoho_settings', 'vintel_zoho_client_secret' );
         register_setting( 'vintel_zoho_settings', 'vintel_zoho_redirect_uri' );
-        register_setting( 'vintel_zoho_settings', 'vintel_zoho_access_token' );
-        register_setting( 'vintel_zoho_settings', 'vintel_zoho_refresh_token' );
-        register_setting( 'vintel_zoho_settings', 'vintel_zoho_token_expires_at' );
+        register_setting( 'vintel_zoho_settings', 'zoho_access_token' );
+        register_setting( 'vintel_zoho_settings', 'zoho_refresh_token' );
+        register_setting( 'vintel_zoho_settings', 'zoho_token_expires_at' );
     }
 
     private function get_auth_url() {
@@ -105,8 +105,8 @@ class Vintel_Zoho_Loader {
             <hr />
 
             <?php
-            $token      = get_option( 'vintel_zoho_access_token' );
-            $expires_at = get_option( 'vintel_zoho_token_expires_at' );
+            $token      = get_option( 'zoho_access_token' );
+            $expires_at = get_option( 'zoho_token_expires_at' );
             if ( $token ) {
                 echo '<p>' . sprintf( esc_html__( 'Access Token Expires: %s', 'vintel-zoho-desk-connector' ), esc_html( $expires_at ) ) . '</p>';
             } else {


### PR DESCRIPTION
## Summary
- ensure API and settings use the same option names

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n 1 -I{} php -l {}`