### PR TITLE
Fix loader init and add basic tests

### DIFF
--- a/includes/class-vintel-zoho-loader.php
+++ b/includes/class-vintel-zoho-loader.php
@@ -148,4 +148,3 @@ class Vintel_Zoho_Loader {
     }
 }
 
-Vintel_Zoho_Loader::get_instance();

--- a/main.php
+++ b/main.php
@@ -32,7 +32,6 @@ register_deactivation_hook( __FILE__, 'vintel_zoho_deactivate' );
 
 // Initialize plugin after all plugins are loaded.
 function vintel_zoho_init() {
-    $loader = new Vintel_Zoho_Loader();
-    $loader->init();
+    Vintel_Zoho_Loader::get_instance();
 }
 add_action( 'plugins_loaded', 'vintel_zoho_init' );

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -1,0 +1,16 @@
+<?php
+require_once __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../includes/class-vintel-zoho-api.php';
+
+$api = new Vintel_Zoho_API();
+
+// No tokens stored should return WP_Error
+$result = $api->create_ticket([
+    'email' => 'a@example.com',
+    'subject' => 'Test',
+    'description' => 'Hello'
+]);
+assert_condition(is_wp_error($result), 'Returns WP_Error when tokens missing');
+
+echo "ApiTest passed\n";
+?>

--- a/tests/OAuthTest.php
+++ b/tests/OAuthTest.php
@@ -1,0 +1,18 @@
+<?php
+require_once __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../includes/class-vintel-zoho-oauth.php';
+
+// Configure options for test
+update_option('vintel_zoho_client_id', 'abc');
+update_option('vintel_zoho_redirect_uri', 'https://example.com/callback');
+
+
+$oauth = new Vintel_Zoho_OAuth();
+$url = $oauth->get_auth_url();
+
+assert_condition(strpos($url, 'https://accounts.zoho.com/oauth/v2/auth') === 0, 'Base auth URL');
+assert_condition(strpos($url, 'client_id=abc') !== false, 'Client ID parameter');
+assert_condition(strpos($url, 'redirect_uri=https%3A%2F%2Fexample.com%2Fcallback') !== false, 'Redirect URI parameter');
+
+echo "OAuthTest passed\n";
+?>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,52 @@
+<?php
+// Minimal stubs for WordPress functions and classes used in tests
+$GLOBALS['wp_options'] = [];
+// Define ABSPATH to satisfy plugin files
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__);
+}
+function get_option($key, $default = false) {
+    return $GLOBALS['wp_options'][$key] ?? $default;
+}
+function update_option($key, $value) {
+    $GLOBALS['wp_options'][$key] = $value;
+}
+function add_option($key, $value) {
+    $GLOBALS['wp_options'][$key] = $value;
+}
+function wp_upload_dir() {
+    return ['basedir' => sys_get_temp_dir()];
+}
+function trailingslashit($path) {
+    return rtrim($path, '/').'/';
+}
+function file_put_contents_safe($file, $data) {
+    return file_put_contents($file, $data);
+}
+function assert_condition($condition, $message) {
+    if (!$condition) {
+        throw new Exception('Assertion failed: ' . $message);
+    }
+}
+function sanitize_text_field($str) { return $str; }
+function sanitize_email($str) { return $str; }
+function sanitize_textarea_field($str) { return $str; }
+function wp_unslash($value) { return $value; }
+function add_query_arg($args, $url) {
+    return $url.'?'.http_build_query($args, '', '&');
+}
+function wp_die($msg) { throw new Exception($msg); }
+class WP_Error {
+    private $message;
+    public function __construct($code = '', $message = '') { $this->message = $message; }
+    public function get_error_message() { return $this->message; }
+}
+function is_wp_error($thing) { return $thing instanceof WP_Error; }
+function wp_remote_post($url, $args = []) {
+    // Simulate successful API response
+    return ['response' => ['code' => 200], 'body' => json_encode(['id' => 123])];
+}
+function wp_remote_retrieve_body($response) { return $response['body']; }
+function wp_remote_retrieve_response_code($response) { return $response['response']['code']; }
+function __($text, $domain = null) { return $text; }
+?>

--- a/tests/run.php
+++ b/tests/run.php
@@ -1,0 +1,9 @@
+<?php
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+echo "Running tests...\n";
+
+require_once __DIR__ . '/OAuthTest.php';
+require_once __DIR__ . '/ApiTest.php';
+?>


### PR DESCRIPTION
## Summary
- fix plugin initialization to use singleton
- remove premature loader instantiation
- add a small test harness with bootstrap and basic tests

## Testing
- `php tests/run.php`
- `find . -name '*.php' -print0 | xargs -0 -n 1 php -l`